### PR TITLE
Node is not an SWIMAddressablePeer, just peers are; pass peers everywhere

### DIFF
--- a/Sources/SWIM/Member.swift
+++ b/Sources/SWIM/Member.swift
@@ -22,7 +22,7 @@ extension SWIM {
         /// Peer reference, used to send messages to this cluster member.
         ///
         /// Can represent the "local" member as well, use `swim.isMyself` to verify if a peer is `myself`.
-        public var peer: AddressableSWIMPeer
+        public var peer: SWIMAddressablePeer
 
         /// `Node` of the member's `peer`.
         public var node: ClusterMembership.Node {
@@ -44,7 +44,7 @@ extension SWIM {
         /// SWIM.Member or deserialized from protobuf. Having this in SWIM.Member ensures we never pass it on the wire and we can't make a mistake when merging suspicions.
         public let suspicionStartedAt: Int64?
 
-        public init(peer: AddressableSWIMPeer, status: SWIM.Status, protocolPeriod: Int, suspicionStartedAt: Int64? = nil) {
+        public init(peer: SWIMAddressablePeer, status: SWIM.Status, protocolPeriod: Int, suspicionStartedAt: Int64? = nil) {
             self.peer = peer
             self.status = status
             self.protocolPeriod = protocolPeriod

--- a/Sources/SWIM/Peer.swift
+++ b/Sources/SWIM/Peer.swift
@@ -16,27 +16,16 @@ import ClusterMembership
 import struct Dispatch.DispatchTime
 import enum Dispatch.DispatchTimeInterval
 
-public protocol AddressableSWIMPeer {
+public protocol SWIMAddressablePeer {
     /// Node that this peer is representing.
     var node: ClusterMembership.Node { get }
 }
 
-extension ClusterMembership.Node: AddressableSWIMPeer {
-    public var node: ClusterMembership.Node {
-        get {
-            self
-        }
-        set {
-            self = newValue
-        }
-    }
-}
-
-public protocol SWIMPingOriginPeer: AddressableSWIMPeer {
+public protocol SWIMPingOriginPeer: SWIMAddressablePeer {
     /// Acknowledge a ping.
     func ack(
         acknowledging: SWIM.SequenceNumber,
-        target: AddressableSWIMPeer,
+        target: SWIMAddressablePeer,
         incarnation: SWIM.Incarnation,
         payload: SWIM.GossipPayload
     )
@@ -44,11 +33,11 @@ public protocol SWIMPingOriginPeer: AddressableSWIMPeer {
     /// "NegativeAcknowledge" a ping.
     func nack(
         acknowledging: SWIM.SequenceNumber,
-        target: AddressableSWIMPeer
+        target: SWIMAddressablePeer
     )
 }
 
-public protocol SWIMPeer: AddressableSWIMPeer {
+public protocol SWIMPeer: SWIMAddressablePeer {
     /// "Ping" another SWIM peer.
     ///
     /// - Parameters:
@@ -58,7 +47,7 @@ public protocol SWIMPeer: AddressableSWIMPeer {
     ///   - onComplete:
     func ping(
         payload: SWIM.GossipPayload,
-        from origin: AddressableSWIMPeer,
+        from origin: SWIMAddressablePeer,
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber,
         onComplete: @escaping (Result<SWIM.PingResponse, Error>) -> Void
@@ -75,9 +64,9 @@ public protocol SWIMPeer: AddressableSWIMPeer {
     ///   - onComplete: must be invoked when the a corresponding reply (ack, nack) or timeout event for this ping request occurs.
     ///     It may be necessary to generate and pass a `SWIM.SequenceNumber` when sending the request, such that the replies can be correlated to this request and completion block.
     func pingRequest(
-        target: AddressableSWIMPeer,
+        target: SWIMAddressablePeer,
         payload: SWIM.GossipPayload,
-        from origin: AddressableSWIMPeer,
+        from origin: SWIMAddressablePeer,
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber,
         onComplete: @escaping (Result<SWIM.PingResponse, Error>) -> Void

--- a/Sources/SWIM/SWIM.swift
+++ b/Sources/SWIM/SWIM.swift
@@ -51,12 +51,12 @@ public enum SWIM {
         /// - parameter target: the target of the ping; i.e. when the pinged node receives a ping, the target is "myself", and that myself should be sent back in the target field.
         /// - parameter incarnation: TODO: docs
         /// - parameter payload: TODO: docs
-        case ack(target: Node, incarnation: Incarnation, payload: GossipPayload, sequenceNumber: SWIM.SequenceNumber)
+        case ack(target: SWIMAddressablePeer, incarnation: Incarnation, payload: GossipPayload, sequenceNumber: SWIM.SequenceNumber)
 
         /// - parameter target: the target of the ping; i.e. when the pinged node receives a ping, the target is "myself", and that myself should be sent back in the target field.
         /// - parameter incarnation: TODO: docs
         /// - parameter payload: TODO: docs
-        case nack(target: Node, sequenceNumber: SWIM.SequenceNumber)
+        case nack(target: SWIMAddressablePeer, sequenceNumber: SWIM.SequenceNumber)
 
         /// Used to signal a response did not arrive within the expected `timeout`.
         ///
@@ -66,7 +66,7 @@ public enum SWIM {
         /// a response not arriving, thus they are all handled via the same timeout response rather than extra "error" responses.
         ///
         /// - parameter target: the target of the ping; i.e. when the pinged node receives a ping, the target is "myself", and that myself should be sent back in the target field.
-        case timeout(target: Node, pingRequestOrigin: Node?, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber)
+        case timeout(target: SWIMAddressablePeer, pingRequestOrigin: SWIMAddressablePeer?, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber)
 
         /// Sequence number of the initial request this is a response to.
         /// Used to pair up responses to the requests which initially caused them.
@@ -163,6 +163,7 @@ extension SWIM.Status {
         }
     }
 
+    /// Returns true if the underlying member status is `.alive`, false otherwise.
     public var isAlive: Bool {
         switch self {
         case .alive:
@@ -172,6 +173,7 @@ extension SWIM.Status {
         }
     }
 
+    /// Returns true if the underlying member status is `.suspect`, false otherwise.
     public var isSuspect: Bool {
         switch self {
         case .suspect:
@@ -181,6 +183,7 @@ extension SWIM.Status {
         }
     }
 
+    /// Returns true if the underlying member status is `.unreachable`, false otherwise.
     public var isUnreachable: Bool {
         switch self {
         case .unreachable:

--- a/Sources/SWIMNIO/Logging.swift
+++ b/Sources/SWIMNIO/Logging.swift
@@ -39,9 +39,9 @@ extension SWIMNIOShell {
     }
 
     internal enum TraceLogType: CustomStringConvertible {
-        case send(to: AddressableSWIMPeer)
-        case reply(to: AddressableSWIMPeer)
-        case receive(pinged: AddressableSWIMPeer?)
+        case send(to: SWIMAddressablePeer)
+        case reply(to: SWIMAddressablePeer)
+        case receive(pinged: SWIMAddressablePeer?)
 
         static var receive: TraceLogType {
             .receive(pinged: nil)

--- a/Sources/SWIMNIO/SWIMProtocolHandler.swift
+++ b/Sources/SWIMNIO/SWIMProtocolHandler.swift
@@ -143,7 +143,7 @@ public final class SWIMProtocolHandler: ChannelDuplexHandler {
 
         do {
             // deserialize ----------------------------------------
-            let message = try self.deserialize(addressedEnvelope.data)
+            let message = try self.deserialize(addressedEnvelope.data, channel: context.channel)
 
             self.log.trace("Read successful: \(message.messageCaseDescription)", metadata: [
                 "remoteAddress": "\(remoteAddress)",
@@ -194,13 +194,14 @@ public final class SWIMProtocolHandler: ChannelDuplexHandler {
 // MARK: Serialization
 
 extension SWIMProtocolHandler {
-    private func deserialize(_ bytes: ByteBuffer) throws -> SWIM.Message {
+    private func deserialize(_ bytes: ByteBuffer, channel: Channel) throws -> SWIM.Message {
         var bytes = bytes
         guard let data = bytes.readData(length: bytes.readableBytes) else {
             throw MissingDataError("No data to read")
         }
 
         let decoder = SWIMNIODefaultDecoder()
+        decoder.userInfo[.channelUserInfoKey] = channel
         return try decoder.decode(SWIM.Message.self, from: data)
     }
 

--- a/Tests/SWIMNIOTests/SWIMNIOEventTests.swift
+++ b/Tests/SWIMNIOTests/SWIMNIOEventTests.swift
@@ -25,11 +25,11 @@ final class SWIMNIOEventTests: EmbeddedClusteredXCTestCase {
 
     var settings: SWIM.Settings!
     lazy var myselfNode = Node(protocol: "udp", host: "127.0.0.1", port: 7001, uid: 1111)
-    lazy var myselfPeer = SWIM.NIOPeer(node: myselfNode, channel: nil)
+    lazy var myselfPeer = SWIM.NIOPeer(node: myselfNode, channel: EmbeddedChannel())
     lazy var myselfMemberAliveInitial = SWIM.Member(peer: myselfPeer, status: .alive(incarnation: 0), protocolPeriod: 0)
 
     let nonExistentNode = Node(protocol: "udp", host: "127.0.0.222", port: 7834, uid: 9324)
-    lazy var nonExistentPeer = SWIM.NIOPeer(node: nonExistentNode, channel: nil)
+    lazy var nonExistentPeer = SWIM.NIOPeer(node: nonExistentNode, channel: EmbeddedChannel())
 
     var group: MultiThreadedEventLoopGroup!
 
@@ -45,7 +45,6 @@ final class SWIMNIOEventTests: EmbeddedClusteredXCTestCase {
     override func tearDown() {
         try! self.group.syncShutdownGracefully()
         self.group = nil
-
         super.tearDown()
     }
 

--- a/Tests/SWIMNIOTests/Utils/BaseXCTestCases.swift
+++ b/Tests/SWIMNIOTests/Utils/BaseXCTestCases.swift
@@ -162,7 +162,7 @@ class BaseClusteredXCTestCase: XCTestCase {
 
         self._shells.forEach { shell in
             do {
-                try shell.myself.channel?.close().wait()
+                try shell.myself.channel.close().wait()
             } catch {
                 () // channel was already closed, that's okey (e.g. we closed it in the test to "crash" a node)
             }

--- a/Tests/SWIMTests/SWIMInstanceTests.swift
+++ b/Tests/SWIMTests/SWIMInstanceTests.swift
@@ -74,7 +74,7 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(otherPeer, status: .suspect(incarnation: 1, suspectedBy: [self.thirdNode]))
         swim.incrementProtocolPeriod()
 
-        try self.validateMark(swim: swim, member: otherPeer, status: .suspect(incarnation: 1, suspectedBy: [self.thirdNode]), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: otherPeer, status: .suspect(incarnation: 1, suspectedBy: [self.thirdNode]), shouldSucceed: false)
 
         XCTAssertEqual(swim.member(for: otherPeer)!.protocolPeriod, 0)
     }
@@ -87,8 +87,8 @@ final class SWIMInstanceTests: XCTestCase {
 
         for i: SWIM.Incarnation in 0 ... 5 {
             swim.incrementProtocolPeriod()
-            try self.validateMark(swim: swim, member: otherPeer, status: .suspect(incarnation: SWIM.Incarnation(i), suspectedBy: [self.thirdNode]), shouldSucceed: true)
-            try self.validateMark(swim: swim, member: otherPeer, status: .alive(incarnation: SWIM.Incarnation(i + 1)), shouldSucceed: true)
+            try self.validateMark(swim: swim, peer: otherPeer, status: .suspect(incarnation: SWIM.Incarnation(i), suspectedBy: [self.thirdNode]), shouldSucceed: true)
+            try self.validateMark(swim: swim, peer: otherPeer, status: .alive(incarnation: SWIM.Incarnation(i + 1)), shouldSucceed: true)
         }
 
         XCTAssertEqual(swim.member(for: otherPeer)!.protocolPeriod, 6)
@@ -102,8 +102,8 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(suspectMember, status: .suspect(incarnation: 1, suspectedBy: [self.thirdNode]))
         swim.incrementProtocolPeriod()
 
-        try self.validateMark(swim: swim, member: suspectMember, status: .suspect(incarnation: 0, suspectedBy: [self.thirdNode]), shouldSucceed: false)
-        try self.validateMark(swim: swim, member: suspectMember, status: .alive(incarnation: 1), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: suspectMember, status: .suspect(incarnation: 0, suspectedBy: [self.thirdNode]), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: suspectMember, status: .alive(incarnation: 1), shouldSucceed: false)
 
         XCTAssertEqual(swim.member(for: suspectMember)!.protocolPeriod, 0)
     }
@@ -115,8 +115,8 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(unreachableMember, status: .unreachable(incarnation: 1))
         swim.incrementProtocolPeriod()
 
-        try self.validateMark(swim: swim, member: unreachableMember, status: .suspect(incarnation: 0, suspectedBy: [self.thirdNode]), shouldSucceed: false)
-        try self.validateMark(swim: swim, member: unreachableMember, status: .alive(incarnation: 1), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: unreachableMember, status: .suspect(incarnation: 0, suspectedBy: [self.thirdNode]), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: unreachableMember, status: .alive(incarnation: 1), shouldSucceed: false)
 
         XCTAssertEqual(swim.member(for: unreachableMember)!.protocolPeriod, 0)
     }
@@ -129,7 +129,7 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(otherPeer, status: .suspect(incarnation: 1, suspectedBy: [self.thirdNode]))
         swim.incrementProtocolPeriod()
 
-        try self.validateMark(swim: swim, member: otherPeer, status: .dead, shouldSucceed: true)
+        try self.validateMark(swim: swim, peer: otherPeer, status: .dead, shouldSucceed: true)
 
         XCTAssertEqual(swim.member(for: otherPeer)!.protocolPeriod, 1)
     }
@@ -142,9 +142,9 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(otherPeer, status: .dead)
         swim.incrementProtocolPeriod()
 
-        try self.validateMark(swim: swim, member: otherPeer, status: .alive(incarnation: 99), shouldSucceed: false)
-        try self.validateMark(swim: swim, member: otherPeer, status: .suspect(incarnation: 99, suspectedBy: [self.thirdNode]), shouldSucceed: false)
-        try self.validateMark(swim: swim, member: otherPeer, status: .dead, shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: otherPeer, status: .alive(incarnation: 99), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: otherPeer, status: .suspect(incarnation: 99, suspectedBy: [self.thirdNode]), shouldSucceed: false)
+        try self.validateMark(swim: swim, peer: otherPeer, status: .dead, shouldSucceed: false)
 
         XCTAssertEqual(swim.member(for: otherPeer)!.protocolPeriod, 0)
     }
@@ -166,7 +166,7 @@ final class SWIMInstanceTests: XCTestCase {
         // thirdPeer pings secondPeer, gets an ack back -- and there secondPeer had to bump its incarnation number // TODO test for that, using Swim.instance?
 
         // and now we get an `ack` back, secondPeer claims that thirdPeer is indeed alive!
-        _ = swim.onPingRequestResponse(.ack(target: thirdPeer.node, incarnation: 2, payload: .none, sequenceNumber: 1), pingedMember: thirdPeer)
+        _ = swim.onPingRequestResponse(.ack(target: thirdPeer, incarnation: 2, payload: .none, sequenceNumber: 1), pingedMember: thirdPeer)
         // may print the result for debugging purposes if one wanted to
 
         // thirdPeer should be alive; after all, secondPeer told us so!
@@ -187,7 +187,7 @@ final class SWIMInstanceTests: XCTestCase {
         // thirdPeer pings secondPeer, yet secondPeer somehow didn't bump its incarnation... so we should NOT accept its refutation
 
         // and now we get an `ack` back, secondPeer claims that thirdPeer is indeed alive!
-        _ = swim.onPingRequestResponse(.ack(target: thirdPeer.node, incarnation: 1, payload: .none, sequenceNumber: 1), pingedMember: thirdPeer)
+        _ = swim.onPingRequestResponse(.ack(target: thirdPeer, incarnation: 1, payload: .none, sequenceNumber: 1), pingedMember: thirdPeer)
         // may print the result for debugging purposes if one wanted to
 
         // thirdPeer should be alive; after all, secondPeer told us so!
@@ -201,7 +201,7 @@ final class SWIMInstanceTests: XCTestCase {
 
         swim.addMember(self.second, status: .suspect(incarnation: 1, suspectedBy: [self.secondNode]))
 
-        _ = swim.onPingRequestResponse(.timeout(target: self.second.node, pingRequestOrigin: nil, timeout: .milliseconds(800), sequenceNumber: 1), pingedMember: self.second)
+        _ = swim.onPingRequestResponse(.timeout(target: self.second, pingRequestOrigin: nil, timeout: .milliseconds(800), sequenceNumber: 1), pingedMember: self.second)
         let resultStatus = swim.member(for: self.second)!.status
         if case .suspect(_, let confirmations) = resultStatus {
             XCTAssertEqual(confirmations, [secondNode, myselfNode])
@@ -532,7 +532,7 @@ final class SWIMInstanceTests: XCTestCase {
 
         swim.addMember(secondPeer, status: .alive(incarnation: 0))
 
-        swim.onEveryPingRequestResponse(.timeout(target: self.secondNode, pingRequestOrigin: nil, timeout: .milliseconds(300), sequenceNumber: 1), pingedMember: secondPeer)
+        swim.onEveryPingRequestResponse(.timeout(target: secondPeer, pingRequestOrigin: nil, timeout: .milliseconds(300), sequenceNumber: 1), pingedMember: secondPeer)
         XCTAssertEqual(swim.localHealthMultiplier, 1)
     }
 
@@ -544,7 +544,7 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(secondPeer, status: .alive(incarnation: 0))
         swim.localHealthMultiplier = 1
         _ = swim.onPingAckResponse(
-            target: secondPeer.node,
+            target: secondPeer,
             incarnation: 0,
             payload: .none,
             pingRequestOrigin: nil,
@@ -580,7 +580,7 @@ final class SWIMInstanceTests: XCTestCase {
         swim.addMember(secondPeer, status: .alive(incarnation: 0))
         swim.localHealthMultiplier = 1
 
-        _ = swim.onPingRequestResponse(.nack(target: secondPeer.node, sequenceNumber: 1), pingedMember: secondPeer)
+        _ = swim.onPingRequestResponse(.nack(target: secondPeer, sequenceNumber: 1), pingedMember: secondPeer)
         XCTAssertEqual(swim.localHealthMultiplier, 1)
     }
 
@@ -837,24 +837,17 @@ final class SWIMInstanceTests: XCTestCase {
     // MARK: utility functions
 
     func validateMark(
-        swim: SWIM.Instance, member: SWIMPeer, status: SWIM.Status, shouldSucceed: Bool,
-        file: StaticString = (#file), line: UInt = #line
-    ) throws {
-        try self.validateMark(swim: swim, node: member.node, status: status, shouldSucceed: shouldSucceed, file: file, line: line)
-    }
-
-    func validateMark(
         swim: SWIM.Instance, member: SWIM.Member, status: SWIM.Status, shouldSucceed: Bool,
         file: StaticString = (#file), line: UInt = #line
     ) throws {
-        try self.validateMark(swim: swim, node: member.node, status: status, shouldSucceed: shouldSucceed, file: file, line: line)
+        try self.validateMark(swim: swim, peer: member.peer, status: status, shouldSucceed: shouldSucceed, file: file, line: line)
     }
 
     func validateMark(
-        swim: SWIM.Instance, node: Node, status: SWIM.Status, shouldSucceed: Bool,
+        swim: SWIM.Instance, peer: SWIMAddressablePeer, status: SWIM.Status, shouldSucceed: Bool,
         file: StaticString = (#file), line: UInt = #line
     ) throws {
-        let markResult = swim.mark(node, as: status)
+        let markResult = swim.mark(peer, as: status)
 
         if shouldSucceed {
             guard case .applied = markResult else {

--- a/Tests/SWIMTests/TestPeer.swift
+++ b/Tests/SWIMTests/TestPeer.swift
@@ -23,10 +23,10 @@ final class TestPeer: Hashable, SWIMPeer {
     var messages: [TestPeer.Message] = []
 
     enum Message {
-        case ping(payload: SWIM.GossipPayload, origin: AddressableSWIMPeer, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber, onComplete: (Result<SWIM.PingResponse, Error>) -> Void)
-        case pingReq(target: AddressableSWIMPeer, payload: SWIM.GossipPayload, origin: AddressableSWIMPeer, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber, onComplete: (Result<SWIM.PingResponse, Error>) -> Void)
-        case ack(target: AddressableSWIMPeer, incarnation: SWIM.Incarnation, payload: SWIM.GossipPayload)
-        case nack(target: AddressableSWIMPeer)
+        case ping(payload: SWIM.GossipPayload, origin: SWIMAddressablePeer, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber, onComplete: (Result<SWIM.PingResponse, Error>) -> Void)
+        case pingReq(target: SWIMAddressablePeer, payload: SWIM.GossipPayload, origin: SWIMAddressablePeer, timeout: DispatchTimeInterval, sequenceNumber: SWIM.SequenceNumber, onComplete: (Result<SWIM.PingResponse, Error>) -> Void)
+        case ack(target: SWIMAddressablePeer, incarnation: SWIM.Incarnation, payload: SWIM.GossipPayload)
+        case nack(target: SWIMAddressablePeer)
     }
 
     init(node: Node) {
@@ -35,7 +35,7 @@ final class TestPeer: Hashable, SWIMPeer {
 
     func ping(
         payload: SWIM.GossipPayload,
-        from origin: AddressableSWIMPeer,
+        from origin: SWIMAddressablePeer,
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber,
         onComplete: @escaping (Result<SWIM.PingResponse, Error>) -> Void
@@ -47,9 +47,9 @@ final class TestPeer: Hashable, SWIMPeer {
     }
 
     func pingRequest(
-        target: AddressableSWIMPeer,
+        target: SWIMAddressablePeer,
         payload: SWIM.GossipPayload,
-        from origin: AddressableSWIMPeer,
+        from origin: SWIMAddressablePeer,
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber,
         onComplete: @escaping (Result<SWIM.PingResponse, Error>) -> Void
@@ -62,7 +62,7 @@ final class TestPeer: Hashable, SWIMPeer {
 
     func ack(
         acknowledging: SWIM.SequenceNumber,
-        target: AddressableSWIMPeer,
+        target: SWIMAddressablePeer,
         incarnation: SWIM.Incarnation,
         payload: SWIM.GossipPayload
     ) {
@@ -74,7 +74,7 @@ final class TestPeer: Hashable, SWIMPeer {
 
     func nack(
         acknowledging: SWIM.SequenceNumber,
-        target: AddressableSWIMPeer
+        target: SWIMAddressablePeer
     ) {
         self.lock.lock()
         defer { self.lock.unlock() }


### PR DESCRIPTION
This vastly improves how we think about peers.

When we decode we need to ensure we get a channel to create a peer, but that's simple enough via userInfo.

This removes the weird conformance of Node to SWIMAddressablePeer and just uses peers everywhere, which is more consistent and composable.