### PR TITLE
[WIP] Instrument the instance and shell using Swift Metrics

### DIFF
--- a/Sources/SWIM/Metrics.swift
+++ b/Sources/SWIM/Metrics.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-cluster-membership open source project
+//
+// Copyright (c) 2018 Apple Inc. and the swift-cluster-membership project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-cluster-membership project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Metrics
+
+extension SWIM {
+    public struct Metrics {
+        /// Number of members (total)
+        let members: Gauge
+        /// Number of members (alive)
+        let membersAlive: Gauge
+        /// Number of members (suspect)
+        let membersSuspect: Gauge
+        /// Number of members (unreachable)
+        let membersUnreachable: Gauge
+        /// Number of members (dead)
+        let membersDead: Gauge
+
+        /// Records time it takes for ping round-trips
+        let roundTripTime: Timer // TODO: could do dimensions
+
+        /// Records time it takes for (every) pingRequest round-trip
+        let pingRequestResponseTimeAll: Timer
+        let pingRequestResponseTimeFirst: Timer
+
+        /// Records the incarnation of the SWIM instance.
+        ///
+        /// Incarnation numbers are bumped whenever the node needs to refute some gossip about itself,
+        /// as such the incarnation number *growth* is an interesting indicator of cluster observation churn.
+        let incarnation: Gauge
+
+        let successfulProbeCount: Gauge
+
+        let failedProbeCount: Gauge
+
+        // TODO: message sizes (count and bytes)
+
+        init(settings: SWIM.Settings) {
+            self.members = Gauge(
+                label: settings.metrics.makeLabel("members"),
+                dimensions: [("status", "all")]
+            )
+            self.membersAlive = Gauge(
+                label: settings.metrics.makeLabel("members"),
+                dimensions: [("status", "alive")]
+            )
+            self.membersSuspect = Gauge(
+                label: settings.metrics.makeLabel("members"),
+                dimensions: [("status", "dead")]
+            )
+            self.membersUnreachable = Gauge(
+                label: settings.metrics.makeLabel("members"),
+                dimensions: [("status", "unreachable")]
+            )
+            self.membersDead = Gauge(
+                label: settings.metrics.makeLabel("members"),
+                dimensions: [("status", "dead")]
+            )
+
+            self.roundTripTime = Timer(label: settings.metrics.makeLabel("responseRoundTrip", "ping"))
+            self.pingRequestResponseTimeAll = Timer(
+                label: settings.metrics.makeLabel("responseRoundTrip", "pingRequest"),
+                dimensions: [("type", "all")]
+            )
+            self.pingRequestResponseTimeFirst = Timer(
+                label: settings.metrics.makeLabel("responseRoundTrip", "pingRequest"),
+                dimensions: [("type", "firstSuccessful")]
+            )
+            self.incarnation = Gauge(label: settings.metrics.makeLabel("incarnation"))
+
+            self.successfulProbeCount = Gauge(
+                label: settings.metrics.makeLabel("incarnation"),
+                dimensions: [("type", "successful")]
+            )
+            self.failedProbeCount = Gauge(
+                label: settings.metrics.makeLabel("incarnation"),
+                dimensions: [("type", "failed")]
+            )
+        }
+    }
+}

--- a/Sources/SWIM/Metrics.swift
+++ b/Sources/SWIM/Metrics.swift
@@ -17,36 +17,41 @@ import Metrics
 extension SWIM {
     public struct Metrics {
         /// Number of members (total)
-        let members: Gauge
+        public let members: Gauge
         /// Number of members (alive)
-        let membersAlive: Gauge
+        public let membersAlive: Gauge
         /// Number of members (suspect)
-        let membersSuspect: Gauge
+        public let membersSuspect: Gauge
         /// Number of members (unreachable)
-        let membersUnreachable: Gauge
+        public let membersUnreachable: Gauge
         /// Number of members (dead)
-        let membersDead: Gauge
+        public let membersDead: Gauge
 
         /// Records time it takes for ping round-trips
-        let roundTripTime: Timer // TODO: could do dimensions
+        public let roundTripTime: Timer // TODO: could do dimensions
 
         /// Records time it takes for (every) pingRequest round-trip
-        let pingRequestResponseTimeAll: Timer
-        let pingRequestResponseTimeFirst: Timer
+        public let pingRequestResponseTimeAll: Timer
+        public let pingRequestResponseTimeFirst: Timer
 
         /// Records the incarnation of the SWIM instance.
         ///
         /// Incarnation numbers are bumped whenever the node needs to refute some gossip about itself,
         /// as such the incarnation number *growth* is an interesting indicator of cluster observation churn.
-        let incarnation: Gauge
+        public let incarnation: Gauge
 
-        let successfulProbeCount: Gauge
+        public let successfulProbeCount: Gauge
 
-        let failedProbeCount: Gauge
+        public let failedProbeCount: Gauge
 
         // TODO: message sizes (count and bytes)
+        public let messageCountInbound: Counter
+        public let messageBytesInbound: Recorder
 
-        init(settings: SWIM.Settings) {
+        public let messageCountOutbound: Counter
+        public let messageBytesOutbound: Recorder
+
+        public init(settings: SWIM.Settings) {
             self.members = Gauge(
                 label: settings.metrics.makeLabel("members"),
                 dimensions: [("status", "all")]
@@ -87,6 +92,63 @@ extension SWIM {
                 label: settings.metrics.makeLabel("incarnation"),
                 dimensions: [("type", "failed")]
             )
+
+            // TODO: how to best design the labels?
+            self.messageCountInbound = Counter(
+                label: settings.metrics.makeLabel("message"),
+                dimensions: [
+                    ("type", "count"),
+                    ("direction", "in"),
+                ]
+            )
+            self.messageBytesInbound = Recorder(
+                label: settings.metrics.makeLabel("message"),
+                dimensions: [
+                    ("type", "bytes"),
+                    ("direction", "in"),
+                ]
+            )
+
+            self.messageCountOutbound = Counter(
+                label: settings.metrics.makeLabel("message"),
+                dimensions: [
+                    ("type", "count"),
+                    ("direction", "out"),
+                ]
+            )
+            self.messageBytesOutbound = Recorder(
+                label: settings.metrics.makeLabel("message"),
+                dimensions: [
+                    ("type", "bytes"),
+                    ("direction", "out"),
+                ]
+            )
         }
+    }
+}
+
+extension SWIM.Metrics {
+    /// Update member metrics metrics based on SWIM's membership.
+    public func updateMembership(_ members: SWIM.Membership) {
+        var alives = 0
+        var suspects = 0
+        var unreachables = 0
+        var deads = 0
+        for member in members {
+            switch member.status {
+            case .alive:
+                alives += 1
+            case .suspect:
+                suspects += 1
+            case .unreachable:
+                unreachables += 1
+            case .dead:
+                deads += 1
+            }
+        }
+        self.membersAlive.record(alives)
+        self.membersSuspect.record(suspects)
+        self.membersUnreachable.record(unreachables)
+        self.membersDead.record(deads)
     }
 }

--- a/Sources/SWIM/Metrics.swift
+++ b/Sources/SWIM/Metrics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the swift-cluster-membership open source project
 //
-// Copyright (c) 2018 Apple Inc. and the swift-cluster-membership project authors
+// Copyright (c) 2020 Apple Inc. and the swift-cluster-membership project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -237,6 +237,8 @@ extension SWIM {
         /// The settings currently in use by this instance.
         public let settings: SWIM.Settings
 
+        public let metrics: SWIM.Metrics
+
         private var node: ClusterMembership.Node {
             self.peer.node
         }
@@ -335,6 +337,7 @@ extension SWIM {
             self.peer = myself
             self._members = [:]
             self.membersToPing = []
+            self.metrics = SWIM.Metrics(settings: settings)
             _ = self.addMember(myself, status: .alive(incarnation: 0))
         }
 

--- a/Sources/SWIM/Settings.swift
+++ b/Sources/SWIM/Settings.swift
@@ -51,6 +51,9 @@ extension SWIM {
         /// Settings of the Lifeguard extensions to the SWIM protocol.
         public var lifeguard: SWIMLifeguardSettings = .init()
 
+        /// Settings for metrics to be emitted by the SWIM.Instance automatically.
+        public var metrics: SWIMMetricsSettings = .init()
+
         /// Configures the node of this SWIM instance explicitly, including allowing setting it's UID.
         ///
         /// Depending on runtime, setting this value explicitly may not be necessary,
@@ -299,5 +302,37 @@ public struct SWIMLifeguardSettings {
         willSet {
             precondition(newValue > 0, "`settings.cluster.swim.maxIndependentSuspicions` MUST BE > 0")
         }
+    }
+}
+
+// ==== ----------------------------------------------------------------------------------------------------------------
+// MARK: SWIM Metrics Settings
+
+/// Configure label names and other details about metrics reported by the `SWIM.Instance`.
+public struct SWIMMetricsSettings {
+    public init() {}
+
+    /// Configure the segments separator for use when creating labels;
+    /// Some systems like graphite like "." as the separator, yet others may not treat this as legal character.
+    ///
+    /// Typical alternative values are "/" or "_", though consult your metrics backend before changing this setting.
+    public var segmentSeparator: String = "."
+
+    /// Prefix all metrics with this segment.
+    ///
+    /// If set, this is used as the first part of a label name, followed by `labelPrefix`.
+    public var systemName: String?
+
+    /// Label string prefixed before all emitted metrics names in their labels.
+    ///
+    /// - SeeAlso: `systemName`, if set, is prefixed before `labelPrefix` when creating label names.
+    public var labelPrefix: String? = "swim"
+
+    func makeLabel(_ segments: String...) -> String {
+        let systemNamePart: String = self.systemName.map { "\($0)\(self.segmentSeparator)" } ?? ""
+        let systemMetricsPrefixPart: String = self.labelPrefix.map { "\($0)\(self.segmentSeparator)" } ?? ""
+        let joinedSegments = segments.joined(separator: self.segmentSeparator)
+
+        return "\(systemNamePart)\(systemMetricsPrefixPart)\(joinedSegments)"
     }
 }


### PR DESCRIPTION
### Motivation:

SWIM is a great example of a very internal piece of clusters which should expose metrics well.

And there's all kinds of types of metrics, gauges for the membership, counters for total messages etc, and recorders for how many data we sent etc.

In this PR trying to explore the best patterns for instrumenting such middleware with swift-metrics.

### Modifications:

- adds metrics configuration
- instruments the specific places with the metrics calls

Still work in progress

### Result:

- Resolves https://github.com/apple/swift-cluster-membership/issues/8