### PR TITLE
Use new-style github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,0 +1,28 @@
+---
+name: Issue Template
+about: Template for reporting general issues with the library
+title: ''
+labels: 0 - new
+assignees: ''
+
+---
+
+### Expected behavior
+<!-- _what you expected to happen_ -->
+
+### Actual behavior
+<!-- _what actually happened_ -->
+
+### Steps to reproduce
+
+<!-- _steps to reproduce the issue, or link to example app / reproducer_ -->
+
+### If possible, minimal yet complete reproducer code (or URL to code)
+
+<!-- _anything to help us reproducing the issue_ -->
+
+### Version/commit hash
+
+<!-- _the tag/commit hash_ -->
+
+### Swift & OS version (output of `swift --version && uname -a`)


### PR DESCRIPTION
It seems the "style" we do this in https://github.com/apple/swift-nio/blob/master/.github/ISSUE_TEMPLATE.md is outdated:

> You are using an old version of issue templates. Please update to the new issue template workflow. [Learn more](https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates)
