### PR TITLE
=minor typo in parameter signature

### DIFF
--- a/Sources/SWIM/Peer.swift
+++ b/Sources/SWIM/Peer.swift
@@ -54,7 +54,7 @@ public protocol SWIMPingRequestOriginPeer: SWIMPingOriginPeer {
     ///   - sequenceNumber: the sequence number of the incoming `pingRequest` that this nack is a response to
     ///   - target: the target peer which was attempted to be pinged but we didn't get an ack from it yet and are sending a nack back eagerly
     func nack(
-        acknowledging: SWIM.SequenceNumber,
+        acknowledging sequenceNumber: SWIM.SequenceNumber,
         target: SWIMPeer
     )
 }


### PR DESCRIPTION
### Motivation:

Documentation and all usage is correct, but we should also include the second parameter name in the protocol.

### Modifications:

- `acknowledging: SWIM.SequenceNumber,` -> `acknowledging sequenceNumber: SWIM.SequenceNumber,`

### Result:

- minor typo