### PR TITLE
+swim adds ability to handle "replacements" of nodes (new UID on same host/port)

### DIFF
--- a/Sources/SWIM/Member.swift
+++ b/Sources/SWIM/Member.swift
@@ -37,7 +37,7 @@ extension SWIM {
         public var status: SWIM.Status
 
         // Period in which protocol period was this state set
-        public var protocolPeriod: Int
+        public var protocolPeriod: UInt64
 
         /// Indicates a _local_ point in time when suspicion was started.
         ///
@@ -46,7 +46,7 @@ extension SWIM {
         public let localSuspicionStartedAt: DispatchTime? // could be "status updated at"?
 
         /// Create a new member.
-        public init(peer: SWIMPeer, status: SWIM.Status, protocolPeriod: Int, suspicionStartedAt: DispatchTime? = nil) {
+        public init(peer: SWIMPeer, status: SWIM.Status, protocolPeriod: UInt64, suspicionStartedAt: DispatchTime? = nil) {
             self.peer = peer
             self.status = status
             self.protocolPeriod = protocolPeriod
@@ -98,9 +98,18 @@ extension SWIM.Member: Hashable, Equatable {
     }
 }
 
-extension SWIM.Member: CustomStringConvertible {
+extension SWIM.Member: CustomStringConvertible, CustomDebugStringConvertible {
     public var description: String {
         var res = "SWIM.Member(\(self.peer), \(self.status), protocolPeriod: \(self.protocolPeriod)"
+        if let suspicionStartedAt = self.localSuspicionStartedAt {
+            res.append(", suspicionStartedAt: \(suspicionStartedAt)")
+        }
+        res.append(")")
+        return res
+    }
+
+    public var debugDescription: String {
+        var res = "SWIM.Member(\(String(reflecting: self.peer)), \(self.status), protocolPeriod: \(self.protocolPeriod)"
         if let suspicionStartedAt = self.localSuspicionStartedAt {
             res.append(", suspicionStartedAt: \(suspicionStartedAt)")
         }

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -483,7 +483,7 @@ extension SWIM {
         ///   but in a round-robin fashion. Instead, a newly joining member is inserted in the membership list at
         ///   a position that is chosen uniformly at random. On completing a traversal of the entire list,
         ///   rearranges the membership list to a random reordering.
-        func nextMemberToPing() -> SWIMPeer? {
+        func nextPeerToPing() -> SWIMPeer? {
             if self.membersToPing.isEmpty {
                 return nil
             }
@@ -548,7 +548,7 @@ extension SWIM {
             self._members[peer.node] = member
 
             if status.isDead {
-                self._members.removeValue(forKey: member.node)
+                self._members.removeValue(forKey: peer.node)
                 self.removeFromMembersToPing(member)
             }
 
@@ -879,7 +879,7 @@ extension SWIM.Instance {
         directives.append(contentsOf: self.checkSuspicionTimeouts())
 
         // 2) if we have someone to ping, let's do so
-        if let toPing = self.nextMemberToPing() {
+        if let toPing = self.nextPeerToPing() {
             directives.append(
                 .sendPing(
                     target: toPing,

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -237,7 +237,8 @@ extension SWIM {
         /// The settings currently in use by this instance.
         public let settings: SWIM.Settings
 
-        private var node: ClusterMembership.Node {
+        /// Node which this SWIM.Instance is representing in the cluster.
+        public var node: ClusterMembership.Node {
             self.peer.node
         }
 
@@ -428,7 +429,7 @@ extension SWIM {
             let member = SWIM.Member(peer: peer, status: status, protocolPeriod: self.protocolPeriod)
             self._members[member.node] = member
 
-            if self.notMyself(member) {
+            if self.notMyself(member) && !member.isDead {
                 // We know this is a new member.
                 //
                 // Newly added members are inserted at a random spot in the list of members

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -372,7 +372,7 @@ extension SWIM {
         // of the cluster. At the end of every ping cycle, the number will be incremented.
         // Suspicion timeouts are based on the protocol period, i.e. if a probe did not
         // reply within any of the `suspicionTimeoutPeriodsMax` rounds, it would be marked as `.suspect`.
-        private var _protocolPeriod: Int = 0
+        private var _protocolPeriod: UInt64 = 0
 
         /// In order to speed up the spreading of "fresh" rumors, we order gossips in their "number of times gossiped",
         /// and thus are able to easily pick the least spread rumor and pick it for the next gossip round.
@@ -591,7 +591,7 @@ extension SWIM {
         }
 
         /// Current SWIM protocol period (i.e. which round of gossip the instance is in).
-        public var protocolPeriod: Int {
+        public var protocolPeriod: UInt64 {
             self._protocolPeriod
         }
 
@@ -1654,7 +1654,7 @@ extension SWIM.Instance {
             "swim/timeoutSuspectsBeforePeriodMax": "\(self.timeoutSuspectsBeforePeriodMax)",
             "swim/timeoutSuspectsBeforePeriodMin": "\(self.timeoutSuspectsBeforePeriodMin)",
             "swim/incarnation": "\(self.incarnation)",
-            "swim/members/all": Logger.Metadata.Value.array(self.members.map { "\($0)" }),
+            "swim/members/all": Logger.Metadata.Value.array(self.members.map { "\(reflecting: $0)" }),
             "swim/members/count": "\(self.notDeadMemberCount)",
             "swim/suspects/count": "\(self.suspects.count)",
         ]

--- a/Sources/SWIMNIOExample/Coding.swift
+++ b/Sources/SWIMNIOExample/Coding.swift
@@ -136,7 +136,7 @@ extension SWIM.Member: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let peer = try container.decode(SWIM.NIOPeer.self, forKey: .node)
         let status = try container.decode(SWIM.Status.self, forKey: .status)
-        let protocolPeriod = try container.decode(Int.self, forKey: .protocolPeriod)
+        let protocolPeriod = try container.decode(UInt64.self, forKey: .protocolPeriod)
         self.init(peer: peer, status: status, protocolPeriod: protocolPeriod, suspicionStartedAt: nil)
     }
 

--- a/Sources/SWIMNIOExample/SWIMNIOShell.swift
+++ b/Sources/SWIMNIOExample/SWIMNIOShell.swift
@@ -164,7 +164,7 @@ public final class SWIMNIOShell {
             }
         }
 
-        self.log.debug("Received ping@\(sequenceNumber)", metadata: self.swim.metadata([
+        self.log.trace("Received ping@\(sequenceNumber)", metadata: self.swim.metadata([
             "swim/ping/pingOrigin": "\(pingOrigin.node)",
             "swim/ping/payload": "\(payload)",
             "swim/ping/seqNr": "\(sequenceNumber)",
@@ -238,7 +238,7 @@ public final class SWIMNIOShell {
             }
         }
 
-        self.log.debug("Receive ping response: \(response)", metadata: self.swim.metadata([
+        self.log.trace("Receive ping response: \(response)", metadata: self.swim.metadata([
             "swim/pingRequest/origin": "\(pingRequestOriginPeer, orElse: "nil")",
             "swim/pingRequest/sequenceNumber": "\(pingRequestSequenceNumber, orElse: "nil")",
             "swim/response": "\(response)",
@@ -341,7 +341,7 @@ public final class SWIMNIOShell {
         timeout: DispatchTimeInterval,
         sequenceNumber: SWIM.SequenceNumber
     ) {
-        self.log.error("Sending ping", metadata: self.swim.metadata([
+        self.log.trace("Sending ping", metadata: self.swim.metadata([
             "swim/target": "\(target)",
             "swim/gossip/payload": "\(payload)",
             "swim/timeout": "\(timeout)",

--- a/Tests/SWIMTests/SWIMInstanceTests.swift
+++ b/Tests/SWIMTests/SWIMInstanceTests.swift
@@ -857,7 +857,7 @@ final class SWIMInstanceTests: XCTestCase {
 
         var seenNodes: [Node] = []
         for _ in 1 ... memberCount {
-            guard let member = swim.nextMemberToPing() else {
+            guard let member = swim.nextPeerToPing() else {
                 XCTFail("Could not fetch member to ping")
                 return
             }
@@ -872,7 +872,7 @@ final class SWIMInstanceTests: XCTestCase {
 
         // should loop around and we should encounter all the same members now
         for _ in 1 ... memberCount {
-            guard let member = swim.nextMemberToPing() else {
+            guard let member = swim.nextPeerToPing() else {
                 XCTFail("Could not fetch member to ping")
                 return
             }
@@ -903,7 +903,7 @@ final class SWIMInstanceTests: XCTestCase {
         let swim = SWIM.Instance(settings: .init(), myself: otherPeer)
 
         XCTAssertTrue(swim.isMember(otherPeer))
-        XCTAssertNil(swim.nextMemberToPing())
+        XCTAssertNil(swim.nextPeerToPing())
     }
 
     func test_addMember_shouldReplaceMemberIfDifferentUID() {
@@ -1267,6 +1267,26 @@ final class SWIMInstanceTests: XCTestCase {
         default:
             XCTFail("Expected confirmingDead a node to be `.applied`, got: \(directive)")
         }
+    }
+
+    func test_confirmDead_shouldRemovePeerFromMembersToPing() throws {
+        var settings = SWIM.Settings()
+        settings.unreachability = .enabled
+        let swim = SWIM.Instance(settings: settings, myself: self.myself)
+
+        _ = swim.addMember(self.second, status: .alive(incarnation: 10))
+        _ = swim.addMember(self.third, status: .alive(incarnation: 10))
+
+        let secondMember = swim.member(for: self.secondNode)!
+
+        _ = swim.confirmDead(peer: self.second)
+        XCTAssertFalse(swim.membersToPing.contains(secondMember))
+
+        XCTAssertNotEqual(swim.nextPeerToPing()?.node, self.second.node)
+        XCTAssertNotEqual(swim.nextPeerToPing()?.node, self.second.node)
+        XCTAssertNotEqual(swim.nextPeerToPing()?.node, self.second.node)
+        XCTAssertNotEqual(swim.nextPeerToPing()?.node, self.second.node)
+        XCTAssertNotEqual(swim.nextPeerToPing()?.node, self.second.node)
     }
 
     // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Tests/SWIMTests/SWIMInstanceTests.swift
+++ b/Tests/SWIMTests/SWIMInstanceTests.swift
@@ -607,7 +607,7 @@ final class SWIMInstanceTests: XCTestCase {
         let swim = SWIM.Instance(settings: SWIM.Settings(), myself: self.myself)
 
         for i in 0 ..< 10 {
-            XCTAssertEqual(swim.protocolPeriod, i)
+            XCTAssertEqual(swim.protocolPeriod, UInt64(i))
             swim.incrementProtocolPeriod()
         }
     }

--- a/Tests/SWIMTests/SWIMInstanceTests.swift
+++ b/Tests/SWIMTests/SWIMInstanceTests.swift
@@ -906,6 +906,16 @@ final class SWIMInstanceTests: XCTestCase {
         XCTAssertNil(swim.nextPeerToPing())
     }
 
+    func test_addMember_shouldNotAddPeerWithoutUID() {
+        let swim = SWIM.Instance(settings: .init(), myself: self.myself)
+
+        let other = TestPeer(node: .init(protocol: "test", host: "127.0.0.1", port: 111, uid: nil))
+        let directives = swim.addMember(other, status: .alive(incarnation: 0))
+        XCTAssertEqual(directives.count, 0)
+        XCTAssertFalse(swim.isMember(other))
+        XCTAssertNil(swim.nextPeerToPing())
+    }
+
     func test_addMember_shouldReplaceMemberIfDifferentUID() {
         let swim = SWIM.Instance(settings: .init(), myself: self.myself)
         _ = swim.addMember(self.second, status: .alive(incarnation: 0))


### PR DESCRIPTION
Turns out we can't ignore this case in SWIM Instance itself, and it should be handled natively here as well, in order to mark nodes dead and remove them from the members/all after all.

### Motivation:

In stable node setup environments where instances can die and be revived on same host/port but get new UIDs when they do, we would not properly handle such a "replacement" coming in on the SWIM layer.

A replacement means that the "old instance on the same host/port is definitely dead, and the new one replaces it" as such an addMember may have to take into account declaring a node dead. This immediately causes .dead and does not care about unreachability.

### Modifications:

- addMember understands that it may be performing a replacement and scans for such potential cases
- adjust for .dead never being gossiped, so the test goes away; that always was the case really

### Result:

- Resolves https://github.com/apple/swift-cluster-membership/issues/67
