### PR TITLE
=fix Small typo in overloaded less-than operator for Node struct

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,13 @@ var targets: [PackageDescription.Target] = [
     // MARK: Tests
 
     .testTarget(
+        name: "ClusterMembershipTests",
+        dependencies: [
+            "ClusterMembership",
+        ]
+    ),
+
+    .testTarget(
         name: "SWIMTests",
         dependencies: [
             "SWIM",

--- a/Sources/ClusterMembership/Node.swift
+++ b/Sources/ClusterMembership/Node.swift
@@ -76,7 +76,7 @@ extension Node {
             }
         } else {
             // "silly" but good enough comparison, we just need a predictable order, does not really matter what it is
-            return "\(lhs.protocol)\(lhs.host)" < "\(lhs.protocol)\(lhs.host)"
+            return "\(lhs.protocol)\(lhs.host)" < "\(rhs.protocol)\(rhs.host)"
         }
     }
 }

--- a/Tests/ClusterMembershipTests/NodeTests.swift
+++ b/Tests/ClusterMembershipTests/NodeTests.swift
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Cluster Membership open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the Swift Cluster Membership project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of Swift Cluster Membership project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import ClusterMembership
+import XCTest
+
+final class NodeTests: XCTestCase {
+    let firstNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.1", port: 7001, uid: 1111)
+    let secondNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.1", port: 7002, uid: 2222)
+    let thirdNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.2", port: 7001, uid: 3333)
+    
+    func testCompareSameProtocolAndHost() throws {
+        XCTAssertLessThan(firstNode, secondNode)
+        XCTAssertGreaterThan(secondNode, firstNode)
+        XCTAssertNotEqual(firstNode, secondNode)
+    }
+
+    func testCompareDifferentHost() throws {
+        XCTAssertLessThan(firstNode, thirdNode)
+    }
+
+    func testSort() throws {
+        let nodes: Set<ClusterMembership.Node> = [secondNode, firstNode, thirdNode]
+        let sorted_nodes = nodes.sorted()
+
+        XCTAssertEqual(sorted_nodes, [firstNode, secondNode, thirdNode])
+    }
+}

--- a/Tests/ClusterMembershipTests/NodeTests.swift
+++ b/Tests/ClusterMembershipTests/NodeTests.swift
@@ -28,6 +28,10 @@ final class NodeTests: XCTestCase {
 
     func testCompareDifferentHost() throws {
         XCTAssertLessThan(firstNode, thirdNode)
+        XCTAssertGreaterThan(thirdNode, firstNode)
+        XCTAssertNotEqual(firstNode, thirdNode)
+        XCTAssertLessThan(secondNode, thirdNode)
+        XCTAssertGreaterThan(thirdNode, secondNode)
     }
 
     func testSort() throws {

--- a/Tests/ClusterMembershipTests/NodeTests.swift
+++ b/Tests/ClusterMembershipTests/NodeTests.swift
@@ -19,25 +19,25 @@ final class NodeTests: XCTestCase {
     let firstNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.1", port: 7001, uid: 1111)
     let secondNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.1", port: 7002, uid: 2222)
     let thirdNode = ClusterMembership.Node(protocol: "test", host: "127.0.0.2", port: 7001, uid: 3333)
-    
+
     func testCompareSameProtocolAndHost() throws {
-        XCTAssertLessThan(firstNode, secondNode)
-        XCTAssertGreaterThan(secondNode, firstNode)
-        XCTAssertNotEqual(firstNode, secondNode)
+        XCTAssertLessThan(self.firstNode, self.secondNode)
+        XCTAssertGreaterThan(self.secondNode, self.firstNode)
+        XCTAssertNotEqual(self.firstNode, self.secondNode)
     }
 
     func testCompareDifferentHost() throws {
-        XCTAssertLessThan(firstNode, thirdNode)
-        XCTAssertGreaterThan(thirdNode, firstNode)
-        XCTAssertNotEqual(firstNode, thirdNode)
-        XCTAssertLessThan(secondNode, thirdNode)
-        XCTAssertGreaterThan(thirdNode, secondNode)
+        XCTAssertLessThan(self.firstNode, self.thirdNode)
+        XCTAssertGreaterThan(self.thirdNode, self.firstNode)
+        XCTAssertNotEqual(self.firstNode, self.thirdNode)
+        XCTAssertLessThan(self.secondNode, self.thirdNode)
+        XCTAssertGreaterThan(self.thirdNode, self.secondNode)
     }
 
     func testSort() throws {
         let nodes: Set<ClusterMembership.Node> = [secondNode, firstNode, thirdNode]
         let sorted_nodes = nodes.sorted()
 
-        XCTAssertEqual(sorted_nodes, [firstNode, secondNode, thirdNode])
+        XCTAssertEqual(sorted_nodes, [self.firstNode, self.secondNode, self.thirdNode])
     }
 }


### PR DESCRIPTION
Fixed a typo using `lhs` on both sides of `<` Node operator.

### Motivation:

The `Node` struct overloads the `<` operator to compare two `Nodes`. This can be used in, for example, [sorting a Set of `Nodes`](https://github.com/apple/swift-cluster-membership/blob/343e2ad672fbfc85c51c0043284261c2e34066ac/Sources/SWIM/SWIMInstance.swift#L376). The current behavior uses the `lhs` argument on both sides of the operator, always trivially returning `false`. This means that any two `Nodes` with the same protocol and host values are incomparable.

If this behavior is intended, I believe it would be clearer to always return `false`.

### Modifications:

I just updated the right-hand side of the comparison to use the `rhs` argument.

### Result:

- Now two `Nodes` will be at least consistently sorted even if they have the same protocol and host values.
