### PR TITLE
ci update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,11 +17,10 @@ RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq # used by integration tests
 
 # ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
-RUN gem install asciidoctor -v 1.5.8 --no-ri --no-rdoc
-RUN gem install asciidoctor-pdf --pre --no-ri --no-rdoc
-RUN gem install asciidoctor-diagram -v 1.5.8 --no-ri --no-rdoc
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
+# jazzy no longer works on older version of ubuntu as ruby is too old.
+RUN if [ "${ubuntu_version}" = "focal" ] ; then echo "gem: --no-document" > ~/.gemrc ; fi
+RUN if [ "${ubuntu_version}" = "focal" ] ; then gem install jazzy ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:20.04-5.4
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.4"
+
+  unit-tests:
+    image: swift-cluster-membership:20.04-5.4
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:20.04-5.4
+
+  integration-tests:
+    image: swift-cluster-membership:20.04-5.4
+
+  test:
+    image: swift-cluster-membership:20.04-5.4
+
+  bench:
+    image: swift-cluster-membership:20.04-5.4
+
+  shell:
+    image: swift-cluster-membership:20.04-5.4
+
+  sample-crash:
+    image: swift-cluster-membership:20.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:20.04-5.5
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.5"
+
+  unit-tests:
+    image: swift-cluster-membership:20.04-5.5
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:20.04-5.5
+
+  integration-tests:
+    image: swift-cluster-membership:20.04-5.5
+
+  test:
+    image: swift-cluster-membership:20.04-5.5
+
+  bench:
+    image: swift-cluster-membership:20.04-5.5
+
+  shell:
+    image: swift-cluster-membership:20.04-5.5
+
+  sample-crash:
+    image: swift-cluster-membership:20.04-5.5

--- a/docker/docker-compose.2004.56.yaml
+++ b/docker/docker-compose.2004.56.yaml
@@ -1,0 +1,31 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:20.04-5.6
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.6"
+
+  unit-tests:
+    image: swift-cluster-membership:20.04-5.6
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:20.04-5.6
+
+  integration-tests:
+    image: swift-cluster-membership:20.04-5.6
+
+  test:
+    image: swift-cluster-membership:20.04-5.6
+
+  bench:
+    image: swift-cluster-membership:20.04-5.6
+
+  shell:
+    image: swift-cluster-membership:20.04-5.6
+
+  sample-crash:
+    image: swift-cluster-membership:20.04-5.6

--- a/docker/docker-compose.2004.57.yaml
+++ b/docker/docker-compose.2004.57.yaml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:20.04-5.7
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-focal"
+
+  unit-tests:
+    image: swift-cluster-membership:20.04-5.7
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:20.04-5.7
+
+  integration-tests:
+    image: swift-cluster-membership:20.04-5.7
+
+  test:
+    image: swift-cluster-membership:20.04-5.7
+
+  bench:
+    image: swift-cluster-membership:20.04-5.7
+
+  shell:
+    image: swift-cluster-membership:20.04-5.7
+
+  sample-crash:
+    image: swift-cluster-membership:20.04-5.7

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -1,0 +1,30 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:20.04-main
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-main-focal"
+
+  unit-tests:
+    image: swift-cluster-membership:20.04-main
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:20.04-main
+
+  integration-tests:
+    image: swift-cluster-membership:20.04-main
+
+  test:
+    image: swift-cluster-membership:20.04-main
+
+  bench:
+    image: swift-cluster-membership:20.04-main
+
+  shell:
+    image: swift-cluster-membership:20.04-main
+
+  sample-crash:
+    image: swift-cluster-membership:20.04-main


### PR DESCRIPTION
motivation: 5.6 is out

changes:
* use missing ci for 5.4, 5.5 and 5.6
* add docker setup for 5.7 (using nightly for now) and nightly
