### PR TITLE
Explicitly depend on SWIM target, to prevent SwiftPM dependency issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,7 +93,7 @@ var targets: [PackageDescription.Target] = [
     .testTarget(
         name: "SWIMTestKit",
         dependencies: [
-//            "SWIM",
+            "SWIM",
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),

--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,7 @@ var targets: [PackageDescription.Target] = [
     .testTarget(
         name: "SWIMTestKit",
         dependencies: [
+//            "SWIM",
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),

--- a/Sources/ClusterMembership/Node.swift
+++ b/Sources/ClusterMembership/Node.swift
@@ -64,10 +64,10 @@ public struct Node: Hashable, Sendable, Comparable, CustomStringConvertible {
     }
 }
 
-extension Node {
+public extension Node {
     // Silly but good enough comparison for deciding "who is lower node"
     // as we only use those for "tie-breakers" any ordering is fine to be honest here.
-    public static func < (lhs: Node, rhs: Node) -> Bool {
+    static func < (lhs: Node, rhs: Node) -> Bool {
         if lhs.protocol == rhs.protocol, lhs.host == rhs.host {
             if lhs.port == rhs.port {
                 return (lhs.uid ?? 0) < (rhs.uid ?? 0)

--- a/docker/docker-compose.2004.main.yaml
+++ b/docker/docker-compose.2004.main.yaml
@@ -10,6 +10,8 @@ services:
 
   unit-tests:
     image: swift-cluster-membership:20.04-main
+    environment:
+      - EXPLICIT_TARGET_DEPENDENCY_IMPORT_CHECK=--explicit-target-dependency-import-check error
 
   unit-tests-until-failure:
     image: swift-cluster-membership:20.04-main
@@ -19,6 +21,8 @@ services:
 
   test:
     image: swift-cluster-membership:20.04-main
+    environment:
+      - EXPLICIT_TARGET_DEPENDENCY_IMPORT_CHECK=--explicit-target-dependency-import-check error
 
   bench:
     image: swift-cluster-membership:20.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -42,7 +42,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -cl "swift test --enable-test-discovery -Xswiftc -DTESTS_LEAKS && ./scripts/integration_tests.sh"
+    command: /bin/bash -cl "swift test $${EXPLICIT_TARGET_DEPENDENCY_IMPORT_CHECK-} --enable-test-discovery -Xswiftc -DTESTS_LEAKS && ./scripts/integration_tests.sh"
 #    command: /bin/bash -cl "WARNINGS_AS_ERRORS=yes swift test --enable-test-discovery -Xswiftc -DTESTS_LEAKS && ./scripts/integration_tests.sh"
 
   # util


### PR DESCRIPTION
resolves #89

And also enables `--explicit-target-dependency-import-check error` on `main` swift so that such problems never creep in again