### PR TITLE
Redirect GitHub Pages to Swift Package Index DocC page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,5 @@
-<html><head><meta http-equiv="refresh" content="0; url=docs/current/SWIM/index.html" /></head></html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url='https://swiftpackageindex.com/apple/swift-cluster-membership/documentation'" />
+  </head>
+</html>


### PR DESCRIPTION
Depends on https://github.com/apple/swift-cluster-membership/pull/92