### PR TITLE
Update CI

### DIFF
--- a/docker/docker-compose.2004.58.yaml
+++ b/docker/docker-compose.2004.58.yaml
@@ -6,7 +6,8 @@ services:
     image: swift-cluster-membership:20.04-5.8
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.8-focal"
+        ubuntu_version: "focal"
+        swift_version: "5.8"
 
   unit-tests:
     image: swift-cluster-membership:20.04-5.8

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-cluster-membership:22.04-5.9
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.9-jammy"
+
+  unit-tests:
+    image: swift-cluster-membership:22.04-5.9
+    environment:
+      - EXPLICIT_TARGET_DEPENDENCY_IMPORT_CHECK=--explicit-target-dependency-import-check error
+
+  unit-tests-until-failure:
+    image: swift-cluster-membership:22.04-5.9
+
+  integration-tests:
+    image: swift-cluster-membership:22.04-5.9
+
+  test:
+    image: swift-cluster-membership:22.04-5.9
+    environment:
+      - EXPLICIT_TARGET_DEPENDENCY_IMPORT_CHECK=--explicit-target-dependency-import-check error
+
+  bench:
+    image: swift-cluster-membership:22.04-5.9
+
+  shell:
+    image: swift-cluster-membership:22.04-5.9
+
+  sample-crash:
+    image: swift-cluster-membership:22.04-5.9


### PR DESCRIPTION
- Swift 5.8 docker images are available
- Add docker-compose for Swift 5.9
