### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -154,3 +154,14 @@ var package = Package(
 
     cxxLanguageStandard: .cxx11
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import ClusterMembership
+import CoreMetrics
 import Logging
 
 import struct Dispatch.DispatchTime

--- a/Sources/SWIMNIOExample/SWIMNIOHandler.swift
+++ b/Sources/SWIMNIOExample/SWIMNIOHandler.swift
@@ -13,12 +13,19 @@
 //===----------------------------------------------------------------------===//
 
 import ClusterMembership
+import CoreMetrics
 import Logging
 import NIO
 import NIOFoundationCompat
 import SWIM
 
 import struct Dispatch.DispatchTime
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// `ChannelDuplexHandler` responsible for encoding/decoding SWIM messages to/from the `SWIMNIOShell`.
 ///

--- a/Sources/SWIMNIOExample/SWIMNIOShell.swift
+++ b/Sources/SWIMNIOExample/SWIMNIOShell.swift
@@ -14,6 +14,7 @@
 
 import ClusterMembership
 import Logging
+import Metrics
 import NIO
 import SWIM
 

--- a/Tests/SWIMNIOExampleTests/SWIMNIOClusteredTests.swift
+++ b/Tests/SWIMNIOExampleTests/SWIMNIOClusteredTests.swift
@@ -16,6 +16,7 @@ import ClusterMembership
 import Logging
 import NIO
 import SWIM
+import SWIMTestKit
 import XCTest
 
 @testable import SWIMNIOExample


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.