### PR TITLE
Switch Samples to newer Swift test matrix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,12 +21,28 @@ jobs:
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
+  construct-samples-matrix:
+    name: Construct samples matrix
+    runs-on: ubuntu-latest
+    outputs:
+      samples-matrix: '${{ steps.generate-matrix.outputs.samples-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "samples-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "swift build --package-path Samples --explicit-target-dependency-import-check error"
+
   samples:
     name: Samples
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-samples-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Samples"
-      matrix_linux_command: "cd Samples/ && swift build --explicit-target-dependency-import-check error"
+      matrix_string: '${{ needs.construct-samples-matrix.outputs.samples-matrix }}'
 
   cxx-interop:
     name: Cxx interop


### PR DESCRIPTION
### Motivation:

To remove all uses of the older workflow so it can be removed to simplify the workflows.

### Modifications:

* Switch the sample building check to use the newer Swift test matrix workflow, `swift_test_matrix.yml`

### Result:

This should make no difference to the samples workflow.