### PR TITLE
Samples workflow in main.yml uses new matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,28 @@ jobs:
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
+  construct-samples-matrix:
+    name: Construct samples matrix
+    runs-on: ubuntu-latest
+    outputs:
+      samples-matrix: '${{ steps.generate-matrix.outputs.samples-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "samples-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "swift build --package-path Samples --explicit-target-dependency-import-check error"
+
   samples:
     name: Samples
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-samples-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Samples"
-      matrix_linux_command: "cd Samples/ && swift build --explicit-target-dependency-import-check error"
+      matrix_string: '${{ needs.construct-samples-matrix.outputs.samples-matrix }}'
 
   macos-tests:
     name: macOS tests


### PR DESCRIPTION
Samples workflow in main.yml uses new matrix

### Motivation:

The samples workflow has been failing in the main.yml version because the adoption of the new test matrix was missed meaning it referred to Swift 6.1 but the old workflow doesn't know how to handle that.

### Modifications:

Migrate the samples job to the new matrix workflow

### Result:

Samples workflows will pass on main and timer jobs