### PR TITLE
Add support for compiling with Static Linux SDK.

### DIFF
--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -20,6 +20,8 @@ import struct Dispatch.DispatchTime
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/SWIM/SWIMProtocol.swift
+++ b/Sources/SWIM/SWIMProtocol.swift
@@ -19,6 +19,8 @@ import struct Dispatch.DispatchTime
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/SWIM/Settings.swift
+++ b/Sources/SWIM/Settings.swift
@@ -19,6 +19,8 @@ import struct Dispatch.DispatchTime
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import func Darwin.log2
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif

--- a/Sources/SWIM/Utils/Heap.swift
+++ b/Sources/SWIM/Utils/Heap.swift
@@ -16,6 +16,8 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #else
 import Glibc
 #endif


### PR DESCRIPTION
### Motivation:

I wanted the ability to cross-compile apps built with this library for small systems like the Raspberry Pi.

### Modifications:

Add conditional import of Musl.

### Result:

Can now cross-compile this project using the Static Linux SDK.

