### PR TITLE
Add support for Musl static Linux SDK

### DIFF
--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -18,10 +18,14 @@ import Logging
 
 import struct Dispatch.DispatchTime
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported platform")
 #endif
 
 extension SWIM {

--- a/Sources/SWIM/SWIMProtocol.swift
+++ b/Sources/SWIM/SWIMProtocol.swift
@@ -17,10 +17,14 @@ import Logging
 
 import struct Dispatch.DispatchTime
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported platform")
 #endif
 
 /// ## Scalable Weakly-consistent Infection-style Process Group Membership Protocol

--- a/Sources/SWIM/Settings.swift
+++ b/Sources/SWIM/Settings.swift
@@ -17,10 +17,14 @@ import Logging
 
 import struct Dispatch.DispatchTime
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-import func Darwin.log2
-#else
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported platform")
 #endif
 
 // ==== ----------------------------------------------------------------------------------------------------------------

--- a/Sources/SWIM/Utils/Heap.swift
+++ b/Sources/SWIM/Utils/Heap.swift
@@ -14,10 +14,14 @@
 
 // Based on https://raw.githubusercontent.com/apple/swift-nio/bf2598d19359e43b4cfaffaff250986ebe677721/Sources/NIO/Heap.swift
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported platform")
 #endif
 
 internal enum HeapType {


### PR DESCRIPTION
### Motivation:

We'd like to get this package building with the static Linux SDK, which will also unblock #112.

### Modifications:

Update the imports to support Musl.

### Result:

Builds with `swift build --swift-sdk swift-6.1-RELEASE_static-linux-0.0.1`.