### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,6 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -90,14 +90,15 @@ var targets: [PackageDescription.Target] = [
     ),
 
     // NOT FOR PUBLIC CONSUMPTION.
-    .testTarget(
+    .target(
         name: "SWIMTestKit",
         dependencies: [
             "SWIM",
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
-        ]
+        ],
+        path: "Tests/SWIMTestKit"
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------

--- a/Samples/Package.swift
+++ b/Samples/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/SWIM/Events.swift
+++ b/Sources/SWIM/Events.swift
@@ -19,7 +19,7 @@ extension SWIM {
     ///
     /// Use `isReachabilityChange` to detect whether the is a change from an alive to unreachable/dead state or not,
     /// and is worth emitting to user-code or not.
-    public struct MemberStatusChangedEvent<Peer: SWIMPeer>: Equatable {
+    public struct MemberStatusChangedEvent<Peer: SWIMPeer>: Equatable, Sendable {
         /// The member that this change event is about.
         public let member: SWIM.Member<Peer>
 

--- a/Sources/SWIM/SWIMInstance.swift
+++ b/Sources/SWIM/SWIMInstance.swift
@@ -1166,7 +1166,7 @@ extension SWIM.Instance {
     ///
     /// Only a single `target` peer is used, however it may be pinged "through" a few other members.
     /// The amount of fan-out in pingRequests is configurable by `swim.indirectProbeCount`.
-    public struct SendPingRequestDirective {
+    public struct SendPingRequestDirective: Sendable {
         /// Target that the should be probed by the `requestDetails.memberToPingRequestThrough` peers.
         public let target: Peer
         /// Timeout to be used for all the ping requests about to be sent.
@@ -1175,7 +1175,7 @@ extension SWIM.Instance {
         public let requestDetails: [PingRequestDetail]
 
         /// Describes a specific ping request to be made.
-        public struct PingRequestDetail {
+        public struct PingRequestDetail: Sendable {
             /// Marks the peer the `pingRequest` should be sent to.
             public let peerToPingRequestThrough: Peer
             /// Additional gossip to carry with the `pingRequest`

--- a/Sources/SWIMNIOExample/Coding.swift
+++ b/Sources/SWIMNIOExample/Coding.swift
@@ -111,7 +111,7 @@ extension CodingUserInfoKey {
     static let channelUserInfoKey = CodingUserInfoKey(rawValue: "nio_peer_channel")!
 }
 
-extension SWIM.NIOPeer: Codable {
+extension SWIM.NIOPeer: @preconcurrency Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let node = try container.decode(Node.self)

--- a/Sources/SWIMNIOExample/Coding.swift
+++ b/Sources/SWIMNIOExample/Coding.swift
@@ -111,7 +111,7 @@ extension CodingUserInfoKey {
     static let channelUserInfoKey = CodingUserInfoKey(rawValue: "nio_peer_channel")!
 }
 
-extension SWIM.NIOPeer: @preconcurrency Codable {
+extension SWIM.NIOPeer: @preconcurrency Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         let node = try container.decode(Node.self)
@@ -120,7 +120,9 @@ extension SWIM.NIOPeer: @preconcurrency Codable {
         }
         self.init(node: node, channel: channel)
     }
+}
 
+extension SWIM.NIOPeer: Encodable {
     public nonisolated func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(self.node)

--- a/Sources/SWIMNIOExample/Message.swift
+++ b/Sources/SWIMNIOExample/Message.swift
@@ -18,7 +18,7 @@ import NIO
 import SWIM
 
 extension SWIM {
-    public enum Message {
+    public enum Message: Sendable {
         case ping(replyTo: NIOPeer, payload: GossipPayload<NIOPeer>, sequenceNumber: SWIM.SequenceNumber)
 
         /// "Ping Request" requests a SWIM probe.
@@ -73,7 +73,7 @@ extension SWIM {
         }
     }
 
-    public enum LocalMessage {
+    public enum LocalMessage: Sendable {
         /// Sent by `ClusterShell` when wanting to join a cluster node by `Node`.
         ///
         /// Requests SWIM to monitor a node, which also causes an association to this node to be requested

--- a/Sources/SWIMNIOExample/SWIMNIOHandler.swift
+++ b/Sources/SWIMNIOExample/SWIMNIOHandler.swift
@@ -31,7 +31,7 @@ import Foundation
 ///
 /// It is designed to work with `DatagramBootstrap`s, and the contained shell can send messages by writing `SWIMNIOSWIMNIOWriteCommand`
 /// data into the channel which this handler converts into outbound `AddressedEnvelope<ByteBuffer>` elements.
-public final class SWIMNIOHandler: ChannelDuplexHandler {
+public final class SWIMNIOHandler: ChannelDuplexHandler, @unchecked Sendable {
     public typealias InboundIn = AddressedEnvelope<ByteBuffer>
     public typealias InboundOut = SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>
     public typealias OutboundIn = SWIMNIOWriteCommand
@@ -66,6 +66,7 @@ public final class SWIMNIOHandler: ChannelDuplexHandler {
             self.settings.swim.node
             ?? Node(protocol: "udp", host: hostIP, port: hostPort, uid: .random(in: 0..<UInt64.max))
         settings.swim.node = node
+        nonisolated(unsafe) let context = context
         self.shell = SWIMNIOShell(
             node: node,
             settings: settings,
@@ -290,7 +291,7 @@ extension SWIMNIOHandler {
 /// Used to a command to the channel pipeline to write the message,
 /// and install a reply handler for the specific sequence number associated with the message (along with a timeout)
 /// when a callback is provided.
-public struct SWIMNIOWriteCommand {
+public struct SWIMNIOWriteCommand: @unchecked Sendable {
     /// SWIM message to be written.
     public let message: SWIM.Message
     /// Address of recipient peer where the message should be written to.
@@ -319,7 +320,7 @@ public struct SWIMNIOWriteCommand {
 // MARK: Callback storage
 
 // TODO: move callbacks into the shell?
-struct PendingResponseCallbackIdentifier: Hashable, CustomStringConvertible {
+struct PendingResponseCallbackIdentifier: Hashable, CustomStringConvertible, Sendable {
     let peerAddress: SocketAddress  // FIXME: UID as well...?
     let sequenceNumber: SWIM.SequenceNumber
 

--- a/Sources/SWIMNIOExample/SWIMNIOShell.swift
+++ b/Sources/SWIMNIOExample/SWIMNIOShell.swift
@@ -26,7 +26,7 @@ import struct Dispatch.DispatchTime
 /// all operations performed on the shell are properly synchronized by hopping to the right event loop.
 ///
 /// - SeeAlso: `SWIM.Instance` for detailed documentation about the SWIM protocol implementation.
-public final class SWIMNIOShell {
+public final class SWIMNIOShell: @unchecked Sendable {
     var swim: SWIM.Instance<SWIM.NIOPeer, SWIM.NIOPeer, SWIM.NIOPeer>!
 
     let settings: SWIMNIO.Settings
@@ -42,7 +42,7 @@ public final class SWIMNIOShell {
         self.myself
     }
 
-    let onMemberStatusChange: (SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>) -> Void
+    let onMemberStatusChange: @Sendable (SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>) -> Void
 
     public var node: Node {
         self.myself.node
@@ -55,7 +55,7 @@ public final class SWIMNIOShell {
         node: Node,
         settings: SWIMNIO.Settings,
         channel: Channel,
-        onMemberStatusChange: @escaping (SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>) -> Void
+        onMemberStatusChange: @escaping @Sendable (SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>) -> Void
     ) {
         self.settings = settings
 
@@ -109,7 +109,7 @@ public final class SWIMNIOShell {
 
     /// Start a *single* timer, to run the passed task after given delay.
     @discardableResult
-    private func schedule(delay: Duration, _ task: @escaping () -> Void) -> SWIMCancellable {
+    private func schedule(delay: Duration, _ task: @escaping @Sendable () -> Void) -> SWIMCancellable {
         self.eventLoop.assertInEventLoop()
 
         let scheduled: Scheduled<Void> = self.eventLoop.scheduleTask(in: delay.toNIO) { () in task() }

--- a/Tests/SWIMNIOExampleTests/SWIMNIOEventClusteredTests.swift
+++ b/Tests/SWIMNIOExampleTests/SWIMNIOEventClusteredTests.swift
@@ -144,7 +144,7 @@ extension ProbeEventHandler {
     }
 }
 
-final class ProbeEventHandler: ChannelInboundHandler {
+final class ProbeEventHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>
 
     var events: [SWIM.MemberStatusChangedEvent<SWIM.NIOPeer>] = []

--- a/Tests/SWIMNIOExampleTests/Utils/BaseXCTestCases.swift
+++ b/Tests/SWIMNIOExampleTests/Utils/BaseXCTestCases.swift
@@ -163,8 +163,9 @@ class BaseClusteredXCTestCase: XCTestCase {
     open override func setUp() {
         super.setUp()
 
+        nonisolated(unsafe) let testCase = self
         self.addTeardownBlock {
-            for shell in self._shells {
+            for shell in testCase._shells {
                 do {
                     try await shell.myself.channel.close()
                 } catch {

--- a/Tests/SWIMTestKit/LogCapture.swift
+++ b/Tests/SWIMTestKit/LogCapture.swift
@@ -21,7 +21,7 @@ import class Foundation.NSLock
 @testable import Logging
 
 /// Testing only utility: Captures all log statements for later inspection.
-public final class LogCapture {
+public final class LogCapture: @unchecked Sendable {
     private var _logs: [CapturedLogMessage] = []
     private let lock = NSLock()
 

--- a/Tests/SWIMTestKit/TestMetrics.swift
+++ b/Tests/SWIMTestKit/TestMetrics.swift
@@ -37,7 +37,7 @@ import XCTest
 ///
 /// Metrics factory which allows inspecting recorded metrics programmatically.
 /// Only intended for tests of the Metrics API itself.
-public final class TestMetrics: MetricsFactory {
+public final class TestMetrics: MetricsFactory, @unchecked Sendable {
     private let lock = NSLock()
 
     public typealias Label = String
@@ -204,7 +204,7 @@ public protocol TestMetric {
     var last: (Date, Value)? { get }
 }
 
-public final class TestCounter: TestMetric, CounterHandler, Equatable {
+public final class TestCounter: TestMetric, CounterHandler, Equatable, @unchecked Sendable {
     public let id: String
     public let label: String
     public let dimensions: [(String, String)]
@@ -259,7 +259,7 @@ public final class TestCounter: TestMetric, CounterHandler, Equatable {
     }
 }
 
-public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
+public final class TestRecorder: TestMetric, RecorderHandler, Equatable, @unchecked Sendable {
     public let id: String
     public let label: String
     public let dimensions: [(String, String)]
@@ -308,7 +308,7 @@ public final class TestRecorder: TestMetric, RecorderHandler, Equatable {
     }
 }
 
-public final class TestTimer: TestMetric, TimerHandler, Equatable {
+public final class TestTimer: TestMetric, TimerHandler, Equatable, @unchecked Sendable {
     public let id: String
     public let label: String
     public var displayUnit: TimeUnit?
@@ -387,7 +387,7 @@ extension NSLock {
 // ==== ----------------------------------------------------------------------------------------------------------------
 // MARK: Errors
 
-public enum TestMetricsError: Error {
+public enum TestMetricsError: Error, @unchecked Sendable {
     case missingMetric(label: String, dimensions: [(String, String)])
     case illegalMetricType(metric: Any, expected: String)
 }

--- a/Tests/SWIMTests/TestPeer.swift
+++ b/Tests/SWIMTests/TestPeer.swift
@@ -18,8 +18,10 @@ import XCTest
 
 @testable import SWIM
 
-final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOriginPeer, CustomStringConvertible {
-    var swimNode: Node
+final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOriginPeer, CustomStringConvertible,
+    @unchecked Sendable
+{
+    let swimNode: Node
 
     let semaphore = DispatchSemaphore(value: 1)
     var messages: [TestPeer.Message] = []

--- a/Tests/SWIMTests/TestPeer.swift
+++ b/Tests/SWIMTests/TestPeer.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import ClusterMembership
-import Dispatch
 import XCTest
 
 @testable import SWIM
@@ -21,9 +20,8 @@ import XCTest
 final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOriginPeer, CustomStringConvertible,
     @unchecked Sendable
 {
-    let swimNode: Node
+    var swimNode: Node
 
-    let semaphore = DispatchSemaphore(value: 1)
     var messages: [TestPeer.Message] = []
 
     enum Message {
@@ -64,10 +62,7 @@ final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOri
         timeout: Duration,
         sequenceNumber: SWIM.SequenceNumber
     ) async throws -> SWIM.PingResponse<TestPeer, TestPeer> {
-        self.semaphore.wait()
-        defer { self.semaphore.signal() }
-
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             self.messages.append(
                 .ping(
                     payload: payload,
@@ -87,10 +82,7 @@ final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOri
         timeout: Duration,
         sequenceNumber: SWIM.SequenceNumber
     ) async throws -> SWIM.PingResponse<TestPeer, TestPeer> {
-        self.semaphore.wait()
-        defer { self.semaphore.signal() }
-
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             self.messages.append(
                 .pingReq(
                     target: target,
@@ -110,9 +102,6 @@ final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOri
         incarnation: SWIM.Incarnation,
         payload: SWIM.GossipPayload<TestPeer>
     ) {
-        self.semaphore.wait()
-        defer { self.semaphore.signal() }
-
         self.messages.append(
             .ack(target: target, incarnation: incarnation, payload: payload, sequenceNumber: sequenceNumber)
         )
@@ -122,9 +111,6 @@ final class TestPeer: Hashable, SWIMPeer, SWIMPingOriginPeer, SWIMPingRequestOri
         acknowledging sequenceNumber: SWIM.SequenceNumber,
         target: TestPeer
     ) {
-        self.semaphore.wait()
-        defer { self.semaphore.signal() }
-
         self.messages.append(.nack(target: target, sequenceNumber: sequenceNumber))
     }
 


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
