### PR TITLE
Do not have test targets do not depend on another test target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,14 +90,15 @@ var targets: [PackageDescription.Target] = [
     ),
 
     // NOT FOR PUBLIC CONSUMPTION.
-    .testTarget(
+    .target(
         name: "SWIMTestKit",
         dependencies: [
             "SWIM",
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
-        ]
+        ],
+        path: "Tests/SWIMTestKit"
     ),
 
     // ==== ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Swift Package Manager's (SwiftPM) native build system supported test targets depending on another test target, while the Swift Build build system does not support this.

Since Swift Build is the default build system on tha main and 6.4 nightly toolchain, we need to update the Package manifest to ensure test targets to not depend on other test targets.

This change modified the 'SWIMTestKit' from `testTarget` to `target`.

Relates to: swiftlang/swift-package-manager#10062